### PR TITLE
feat: add kintone ai customizer plugin skeleton

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI/CD
+
+on:
+  push:
+    branches: [main, work]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: services/kintone-ai-customizer/plugin
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'pnpm'
+      - run: pnpm install
+      - run: pnpm lint
+      - run: pnpm test
+      - run: pnpm build
+      - name: Upload artifact
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        uses: actions/upload-artifact@v4
+        with:
+          name: plugin-dist
+          path: dist

--- a/services/kintone-ai-customizer/plugin/.eslintrc.cjs
+++ b/services/kintone-ai-customizer/plugin/.eslintrc.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  root: true,
+  env: { browser: true, es2021: true },
+  parser: '@typescript-eslint/parser',
+  parserOptions: { ecmaVersion: 'latest', sourceType: 'module' },
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'prettier'],
+  plugins: ['@typescript-eslint'],
+  rules: {},
+};

--- a/services/kintone-ai-customizer/plugin/.gitignore
+++ b/services/kintone-ai-customizer/plugin/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+
+# plugin assets
+icon*.png
+screenshot*.png

--- a/services/kintone-ai-customizer/plugin/.prettierrc
+++ b/services/kintone-ai-customizer/plugin/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": true
+}

--- a/services/kintone-ai-customizer/plugin/README.md
+++ b/services/kintone-ai-customizer/plugin/README.md
@@ -1,0 +1,53 @@
+# kintone-ai-customizer plugin
+
+設定画面から要件と最小設定を入力し、AI経由でJS/CSSカスタマイズを生成してkintoneへ適用するためのプラグイン雛形です。
+
+## ディレクトリ構成
+```
+plugin/
+  src/
+    config-ui/    # 設定画面(Vue3 + Pinia)
+    core/         # スキーマ・定数
+    providers/    # AI / kintone プロバイダ
+    templates/    # プロンプト・コード雛形
+    utils/        # 共通
+  tests/          # vitest
+```
+
+## アイコンとスクリーンショット
+このリポジトリにはプラグインのアイコンやスクリーンショット画像を含めていません。`icon.png` や `screenshot.png` を `plugin/` 直下に配置してからビルドしてください。
+
+## コマンド
+依存インストール:
+```
+pnpm install
+```
+開発サーバー:
+```
+pnpm dev
+```
+ビルド:
+```
+pnpm build
+```
+Lint:
+```
+pnpm lint
+```
+テスト:
+```
+pnpm test
+```
+
+## CI/CD
+GitHub Actions により、プッシュやプルリクエスト時に `pnpm lint`・`pnpm test`・`pnpm build` が自動実行されます。`main` ブランチへプッシュされた際はビルド成果物がアーティファクトとして保存されます。ワークフロー定義は `.github/workflows/ci.yml` を参照してください。
+
+## Dry-run 手順
+1. `pnpm dev` で設定画面を起動
+2. 各項目と要件を入力し **Dry Run** をクリック
+3. ダミーAIとデプロイヤが差分JSONを表示
+
+## 将来拡張
+- `providers/ai` に `IAiProvider` 実装を追加することで別AIプロバイダに対応
+- `templates/prompt.ts` を差し替えてプロンプト拡張
+- `providers/kintone` に本番デプロイロジックを実装

--- a/services/kintone-ai-customizer/plugin/package.json
+++ b/services/kintone-ai-customizer/plugin/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "kintone-ai-customizer-plugin",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vue-tsc --noEmit && vite build",
+    "lint": "eslint \"src/**/*.{ts,vue}\"",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "vue": "^3.4.21",
+    "pinia": "^2.1.7",
+    "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^7.2.0",
+    "@typescript-eslint/parser": "^7.2.0",
+    "@vitejs/plugin-vue": "^5.0.4",
+    "eslint": "^8.56.0",
+    "eslint-config-prettier": "^9.1.0",
+    "prettier": "^3.2.5",
+    "typescript": "^5.4.2",
+    "vite": "^5.2.0",
+    "vitest": "^1.3.1",
+    "vue-tsc": "^1.8.27"
+  }
+}

--- a/services/kintone-ai-customizer/plugin/plugin.manifest.json
+++ b/services/kintone-ai-customizer/plugin/plugin.manifest.json
@@ -1,0 +1,14 @@
+{
+  "manifest_version": 1,
+  "name": {
+    "en": "AI Customizer",
+    "ja": "AIカスタマイザー"
+  },
+  "version": "0.1.0",
+  "type": "APP",
+  "description": {
+    "en": "Generate and deploy JS/CSS via AI",
+    "ja": "生成AIでJS/CSSを生成して適用"
+  },
+  "icon": "icon.png"
+}

--- a/services/kintone-ai-customizer/plugin/src/config-ui/App.vue
+++ b/services/kintone-ai-customizer/plugin/src/config-ui/App.vue
@@ -1,0 +1,66 @@
+<template>
+  <div class="config">
+    <h1>AI カスタマイザー設定</h1>
+    <form @submit.prevent="handleSubmit">
+      <label>kintoneDomain<input v-model="form.kintoneDomain" /></label>
+      <label>appId<input v-model="form.appId" /></label>
+      <label>apiToken<input type="password" v-model="form.apiToken" /></label>
+      <label>applyScope<select v-model="form.applyScope" multiple>
+        <option value="index">一覧</option>
+        <option value="detail">詳細</option>
+        <option value="create">新規</option>
+        <option value="edit">編集</option>
+      </select></label>
+      <label>injectPosition<select v-model="form.injectPosition">
+        <option value="header">ヘッダ</option>
+        <option value="footer">フッタ</option>
+        <option value="button">ボタン</option>
+      </select></label>
+      <label>rollbackRetention<input type="number" v-model.number="form.rollbackRetention" /></label>
+      <label>safeMode<input type="checkbox" v-model="form.safeMode" /></label>
+      <label>要件<textarea v-model="form.requirements" /></label>
+      <button type="submit">Dry Run</button>
+    </form>
+    <pre v-if="diff">{{ diff }}</pre>
+    <pre v-if="error" class="error">{{ error }}</pre>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { reactive, ref } from 'vue';
+import { useConfigStore } from './store';
+import { configSchema } from '../core/schema';
+import { DummyAiProvider } from '../providers/ai/DummyAiProvider';
+import { DummyKintoneDeployer } from '../providers/kintone/DummyKintoneDeployer';
+
+const store = useConfigStore();
+const form = reactive({ ...store.config });
+const diff = ref('');
+const error = ref('');
+
+const handleSubmit = async () => {
+  error.value = '';
+  diff.value = '';
+  const parse = configSchema.safeParse(form);
+  if (!parse.success) {
+    error.value = JSON.stringify(parse.error.format(), null, 2);
+    return;
+  }
+  store.setConfig(parse.data);
+  const ai = new DummyAiProvider();
+  const code = await ai.generate(parse.data);
+  const deployer = new DummyKintoneDeployer();
+  const plan = await deployer.dryRun(parse.data, code);
+  diff.value = JSON.stringify(plan, null, 2);
+};
+</script>
+
+<style scoped>
+.config {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-width: 600px;
+}
+.error { color: red; }
+</style>

--- a/services/kintone-ai-customizer/plugin/src/config-ui/main.ts
+++ b/services/kintone-ai-customizer/plugin/src/config-ui/main.ts
@@ -1,0 +1,7 @@
+import { createApp } from 'vue';
+import { createPinia } from 'pinia';
+import App from './App.vue';
+
+const app = createApp(App);
+app.use(createPinia());
+app.mount('#app');

--- a/services/kintone-ai-customizer/plugin/src/config-ui/store.ts
+++ b/services/kintone-ai-customizer/plugin/src/config-ui/store.ts
@@ -1,0 +1,22 @@
+import { defineStore } from 'pinia';
+import type { Config } from '../core/schema';
+
+export const useConfigStore = defineStore('config', {
+  state: () => ({
+    config: {
+      kintoneDomain: '',
+      appId: '',
+      apiToken: '',
+      applyScope: ['index'],
+      injectPosition: 'header',
+      rollbackRetention: 5,
+      safeMode: true,
+      requirements: '',
+    } as Config,
+  }),
+  actions: {
+    setConfig(cfg: Config) {
+      this.config = cfg;
+    },
+  },
+});

--- a/services/kintone-ai-customizer/plugin/src/core/constants.ts
+++ b/services/kintone-ai-customizer/plugin/src/core/constants.ts
@@ -1,0 +1,1 @@
+export const NAMESPACE = '__aiCustomizer__';

--- a/services/kintone-ai-customizer/plugin/src/core/schema.ts
+++ b/services/kintone-ai-customizer/plugin/src/core/schema.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+export const configSchema = z.object({
+  kintoneDomain: z.string().url(),
+  appId: z.string().min(1),
+  apiToken: z.string().min(1),
+  applyScope: z.array(z.enum(['index', 'detail', 'create', 'edit'])).default(['index']),
+  injectPosition: z.enum(['header', 'footer', 'button']).default('header'),
+  rollbackRetention: z.number().int().min(1).max(20).default(5),
+  safeMode: z.boolean().default(true),
+  requirements: z.string().min(1),
+});
+
+export type Config = z.infer<typeof configSchema>;

--- a/services/kintone-ai-customizer/plugin/src/providers/ai/DummyAiProvider.ts
+++ b/services/kintone-ai-customizer/plugin/src/providers/ai/DummyAiProvider.ts
@@ -1,0 +1,11 @@
+import type { IAiProvider } from './IAiProvider';
+import type { Config } from '../../core/schema';
+
+export class DummyAiProvider implements IAiProvider {
+  async generate(_: Config): Promise<{ js: string; css: string }> {
+    return {
+      js: `console.log('ai:hello from ${Date.now()}');`,
+      css: ''
+    };
+  }
+}

--- a/services/kintone-ai-customizer/plugin/src/providers/ai/IAiProvider.ts
+++ b/services/kintone-ai-customizer/plugin/src/providers/ai/IAiProvider.ts
@@ -1,0 +1,5 @@
+import type { Config } from '../../core/schema';
+
+export interface IAiProvider {
+  generate(config: Config): Promise<{ js: string; css: string }>;
+}

--- a/services/kintone-ai-customizer/plugin/src/providers/kintone/DummyKintoneDeployer.ts
+++ b/services/kintone-ai-customizer/plugin/src/providers/kintone/DummyKintoneDeployer.ts
@@ -1,0 +1,9 @@
+import type { IKintoneDeployer } from './IKintoneDeployer';
+import type { Config } from '../../core/schema';
+
+export class DummyKintoneDeployer implements IKintoneDeployer {
+  async dryRun(config: Config, artifacts: { js: string; css: string }): Promise<{ diff: string }> {
+    const diff = `Would deploy JS(${artifacts.js.length} chars) and CSS(${artifacts.css.length} chars) to app ${config.appId}`;
+    return { diff };
+  }
+}

--- a/services/kintone-ai-customizer/plugin/src/providers/kintone/IKintoneDeployer.ts
+++ b/services/kintone-ai-customizer/plugin/src/providers/kintone/IKintoneDeployer.ts
@@ -1,0 +1,5 @@
+import type { Config } from '../../core/schema';
+
+export interface IKintoneDeployer {
+  dryRun(config: Config, artifacts: { js: string; css: string }): Promise<{ diff: string }>;
+}

--- a/services/kintone-ai-customizer/plugin/src/templates/code.ts
+++ b/services/kintone-ai-customizer/plugin/src/templates/code.ts
@@ -1,0 +1,4 @@
+import { NAMESPACE } from '../core/constants';
+
+export const jsTemplate = () => `export function init() {\n  console.log('${NAMESPACE}:init');\n}`;
+export const cssTemplate = () => `.${NAMESPACE}-root {}`;

--- a/services/kintone-ai-customizer/plugin/src/templates/prompt.ts
+++ b/services/kintone-ai-customizer/plugin/src/templates/prompt.ts
@@ -1,0 +1,11 @@
+import type { Config } from '../core/schema';
+import { NAMESPACE } from '../core/constants';
+
+export const buildPrompt = (config: Config): string => {
+  return `あなたはkintone向けフロントエンド実装AIです。\n` +
+    `目的: 入力要件に基づき、安全なJS/CSSカスタマイズを生成する。\n` +
+    `名前空間は ${NAMESPACE} のみを使用。\n` +
+    `要件: ${config.requirements}\n` +
+    `適用範囲: ${config.applyScope.join(',')}\n` +
+    `挿入位置: ${config.injectPosition}\n`; 
+};

--- a/services/kintone-ai-customizer/plugin/src/utils/logger.ts
+++ b/services/kintone-ai-customizer/plugin/src/utils/logger.ts
@@ -1,0 +1,4 @@
+export const logger = {
+  info: (...args: unknown[]) => console.log('ai:', ...args),
+  error: (...args: unknown[]) => console.error('ai:', ...args),
+};

--- a/services/kintone-ai-customizer/plugin/tests/dummy.test.ts
+++ b/services/kintone-ai-customizer/plugin/tests/dummy.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { DummyAiProvider } from '../src/providers/ai/DummyAiProvider';
+import { configSchema } from '../src/core/schema';
+
+const sample = configSchema.parse({
+  kintoneDomain: 'https://example.com',
+  appId: '1',
+  apiToken: 'token',
+  applyScope: ['index'],
+  injectPosition: 'header',
+  rollbackRetention: 5,
+  safeMode: true,
+  requirements: '一覧でボタンを追加',
+});
+
+describe('DummyAiProvider', () => {
+  it('returns js and css', async () => {
+    const ai = new DummyAiProvider();
+    const code = await ai.generate(sample);
+    expect(code.js).toContain('ai:hello');
+  });
+});

--- a/services/kintone-ai-customizer/plugin/tsconfig.json
+++ b/services/kintone-ai-customizer/plugin/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "preserve",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "types": ["vite/client"]
+  },
+  "include": ["src", "tests"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/services/kintone-ai-customizer/plugin/vite.config.ts
+++ b/services/kintone-ai-customizer/plugin/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+
+export default defineConfig({
+  plugins: [vue()],
+  root: 'src/config-ui',
+  build: {
+    outDir: '../../dist/config-ui',
+    emptyOutDir: true,
+  },
+});


### PR DESCRIPTION
## Summary
- scaffold kintone AI customizer plugin with Vue3 config UI
- define AI and kintone provider interfaces with dummy implementations
- add prompt and code templates for future AI generation
- set up GitHub Actions workflow for CI/CD
- ignore plugin icon assets and document manual placement

## Testing
- `pnpm install` *(fails: Proxy response (403) when HTTP Tunneling)*
- `pnpm lint` *(fails: Proxy response (403) when HTTP Tunneling)*
- `pnpm test` *(fails: Proxy response (403) when HTTP Tunneling)*
- `pnpm build` *(fails: Proxy response (403) when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_68b251cc7ba0832491f99f0ea3298a14